### PR TITLE
Fix typo on file config.json.

### DIFF
--- a/system/Synapse/synapse/config.json
+++ b/system/Synapse/synapse/config.json
@@ -81,7 +81,7 @@
 		values:{
 			0:"∞",
 			3000:{en:"3 seconds",de:"3 Sekunden",fr:"3 secondes",pt:"3 segundos",tr:"3 saniye"},
-			5000:{en:"5 seconds",de:"5 Sekunden",fr"5 secondes",pt:"5 segundos",tr:"5 saniye"},
+			5000:{en:"5 seconds",de:"5 Sekunden",fr:"5 secondes",pt:"5 segundos",tr:"5 saniye"},
 		}
 	}},
     ]


### PR DESCRIPTION
It was missing a colon after 'fr' in line 84, and that makes the Synapse fall back into English instead of using the translation.
